### PR TITLE
feat(plugin): remove --config flag

### DIFF
--- a/compose/internal/composeplugin/composeplugin.go
+++ b/compose/internal/composeplugin/composeplugin.go
@@ -16,7 +16,7 @@ import (
 )
 
 var (
-	MissingDockerComposePluginErr = errors.New("docker-compose plugin is missing from config path")
+	MissingDockerComposePluginErr = errors.New("docker compose plugin is missing from config path")
 )
 
 // PluginWrapper provide a type for managing docker compose commands
@@ -25,7 +25,7 @@ type PluginWrapper struct {
 	configPath string
 }
 
-// NewPluginWrapper initializes a new ComposeWrapper service with local docker-compose binary.
+// NewPluginWrapper initializes a new ComposeWrapper service with local docker binary.
 func NewPluginWrapper(binaryPath, configPath string) (libstack.Deployer, error) {
 	if !utils.IsBinaryPresent(utils.ProgramPath(binaryPath, "docker")) {
 		return nil, liberrors.ErrBinaryNotFound
@@ -107,10 +107,6 @@ func (wrapper *PluginWrapper) command(command composeCommand, workingDir, url, p
 
 	args := []string{}
 
-	if wrapper.configPath != "" {
-		args = append(args, "--config", wrapper.configPath)
-	}
-
 	if url != "" {
 		args = append(args, "-H", url)
 	}
@@ -160,10 +156,6 @@ func newDownCommand(filePaths []string) composeCommand {
 
 func newPullCommand(filePaths []string) composeCommand {
 	return newCommand([]string{"pull"}, filePaths)
-}
-
-func (command *composeCommand) WithConfigPath(configPath string) {
-	command.args = append(command.args, "--config", configPath)
 }
 
 func (command *composeCommand) WithProjectName(projectName string) {


### PR DESCRIPTION
This PR removes the --config flag used by the Compose plugin implementation as it is now unsupported.

```
docker compose version
Docker Compose version v2.2.3

docker --config /tmp/.docker compose
unknown flag: --config
```

Not to be merged yet, but can be merged when we decide to bump up the version of the Compose plugin embedded in Portainer.