### PR TITLE
fix: don't install the docker-compose binary [EE-3631]

### DIFF
--- a/compose/compose_test.go
+++ b/compose/compose_test.go
@@ -2,6 +2,7 @@ package compose_test
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log"
 	"os"
@@ -13,7 +14,15 @@ import (
 	"github.com/portainer/docker-compose-wrapper/compose"
 )
 
+func checkPrerequisites(t *testing.T) {
+	if _, err := os.Stat("docker-compose"); errors.Is(err, os.ErrNotExist) {
+		t.Fatal("docker-compose binary not found, please run download.sh and re-run this suite")
+	}
+}
+
 func Test_UpAndDown(t *testing.T) {
+	checkPrerequisites(t)
+
 	deployer, _ := compose.NewComposeDeployer("", "")
 
 	const composeFileContent = `
@@ -49,7 +58,7 @@ func Test_UpAndDown(t *testing.T) {
 
 	ctx := context.Background()
 
-	err = deployer.Deploy(ctx, "", "", "test1", []string{filePathOriginal, filePathOverride}, "", false)
+	err = deployer.Deploy(ctx, "", "", "", []string{filePathOriginal, filePathOverride}, "", false)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -58,7 +67,7 @@ func Test_UpAndDown(t *testing.T) {
 		t.Fatal("container should exist")
 	}
 
-	err = deployer.Remove(ctx, "", "", "test1", []string{filePathOriginal, filePathOverride}, "")
+	err = deployer.Remove(ctx, "", "", "", []string{filePathOriginal, filePathOverride}, "")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/compose/compose_test.go
+++ b/compose/compose_test.go
@@ -58,7 +58,7 @@ func Test_UpAndDown(t *testing.T) {
 		t.Fatal("container should exist")
 	}
 
-	err = deployer.Remove(ctx, "", "", "test1", []string{filePathOriginal, filePathOverride})
+	err = deployer.Remove(ctx, "", "", "test1", []string{filePathOriginal, filePathOverride}, "")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/compose/download.sh
+++ b/compose/download.sh
@@ -1,58 +1,25 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -euo pipefail
-IFS=$'\n\t'
 
-PLATFORM=$1
-ARCH=$2
-DOCKER_COMPOSE_VERSION=$3
+PLATFORM=$(go env GOOS)
+ARCH=$(go env GOARCH)
+COMPOSE_VERSION=v2.5.1
 
-function download_binary() {
-    local PLATFORM=$1
-    local ARCH=$2
-    local BINARY_VERSION=$3
-    
-    if [ "${PLATFORM}" == 'linux' ] && [ "${ARCH}" == 'amd64' ]; then
-        wget -O "dist/docker-compose" "https://github.com/portainer/docker-compose-linux-amd64-static-binary/releases/download/${BINARY_VERSION}/docker-compose"
-        chmod +x "dist/docker-compose"
-        return
-    fi
-    
-    if [ "${PLATFORM}" == 'mac' ]; then
-        wget -O "dist/docker-compose" "https://github.com/docker/compose/releases/download/${BINARY_VERSION}/docker-compose-Darwin-x86_64"
-        chmod +x "dist/docker-compose"
-        return
-    fi
-    
-    if [ "${PLATFORM}" == 'win' ]; then
-        wget -O "dist/docker-compose.exe" "https://github.com/docker/compose/releases/download/${BINARY_VERSION}/docker-compose-Windows-x86_64.exe"
-        chmod +x "dist/docker-compose.exe"
-        return
-    fi
-}
 
-function download_plugin() {
-    local PLATFORM=$1
-    local ARCH=$2
-    local PLUGIN_VERSION=$3
-    
-    if [ "${PLATFORM}" == 'mac' ]; then
-        PLATFORM="darwin"
-    fi
-    
-    FILENAME="docker-compose-${PLATFORM}-${ARCH}"
-    TARGET_FILENAME="docker-compose.plugin"
-    if [[ "$PLATFORM" == "windows" ]]; then
-        FILENAME="$FILENAME.exe"
-        TARGET_FILENAME="$TARGET_FILENAME.exe"
-    fi
-    
-    wget -O "dist/$TARGET_FILENAME" "https://github.com/docker/compose-cli/releases/download/v$PLUGIN_VERSION/$FILENAME"
-    chmod +x "dist/$TARGET_FILENAME"
-    return 0
-}
-
-if [ "${PLATFORM}" == 'linux' ] && [ "${ARCH}" != 'amd64' ]; then
-    download_plugin "$PLATFORM" "$ARCH" "$DOCKER_COMPOSE_VERSION"
+if [[ ${ARCH} == "amd64" ]]; then
+    ARCH="x86_64"
+elif [[ ${ARCH} == "arm" ]]; then
+    ARCH="armv7"
+elif [[ ${ARCH} == "arm64" ]]; then
+    ARCH="aarch64"
 fi
 
-download_binary "$PLATFORM" "$ARCH" "$DOCKER_COMPOSE_VERSION"
+
+if [[ "$PLATFORM" == "windows" ]]; then
+    wget -O "docker-compose.exe" "https://github.com/docker/compose/releases/download/$COMPOSE_VERSION/docker-compose-windows-${ARCH}.exe"
+    chmod +x "docker-compose.exe"
+else
+    wget -O "docker-compose" "https://github.com/docker/compose/releases/download/$COMPOSE_VERSION/docker-compose-${PLATFORM}-${ARCH}"
+    chmod +x "docker-compose"
+fi
+

--- a/compose/internal/composeplugin/composeplugin.go
+++ b/compose/internal/composeplugin/composeplugin.go
@@ -4,14 +4,11 @@ import (
 	"bytes"
 	"context"
 	"log"
-	"os"
 	"os/exec"
-	"path"
 	"strings"
 
 	"github.com/pkg/errors"
 	libstack "github.com/portainer/docker-compose-wrapper"
-	liberrors "github.com/portainer/docker-compose-wrapper/compose/errors"
 	"github.com/portainer/docker-compose-wrapper/compose/internal/utils"
 )
 
@@ -27,34 +24,7 @@ type PluginWrapper struct {
 
 // NewPluginWrapper initializes a new ComposeWrapper service with local docker-compose binary.
 func NewPluginWrapper(binaryPath, configPath string) (libstack.Deployer, error) {
-	if !utils.IsBinaryPresent(utils.ProgramPath(binaryPath, "docker")) {
-		return nil, liberrors.ErrBinaryNotFound
-	}
-
-	if configPath == "" {
-		homePath, err := os.UserHomeDir()
-		if err != nil {
-			return nil, errors.WithMessage(err, "failed fetching user home directory")
-		}
-		configPath = path.Join(homePath, ".docker")
-	}
-
-	dockerPluginsPath := path.Join(configPath, "cli-plugins")
-	pluginPath := utils.ProgramPath(binaryPath, "docker-compose.plugin")
-
-	if utils.IsBinaryPresent(pluginPath) {
-		if !utils.IsBinaryPresent(utils.ProgramPath(dockerPluginsPath, "docker-compose")) {
-			err := os.MkdirAll(dockerPluginsPath, 0755)
-			if err != nil {
-				return nil, errors.WithMessage(err, "failed creating plugins path")
-			}
-		}
-
-		err := utils.Move(pluginPath, utils.ProgramPath(dockerPluginsPath, "docker-compose"))
-		if err != nil {
-			return nil, err
-		}
-	} else if !utils.IsBinaryPresent(utils.ProgramPath(dockerPluginsPath, "docker-compose")) {
+	if !utils.IsBinaryPresent(utils.ProgramPath(binaryPath, "docker-compose")) {
 		return nil, MissingDockerComposePluginErr
 	}
 
@@ -62,15 +32,15 @@ func NewPluginWrapper(binaryPath, configPath string) (libstack.Deployer, error) 
 }
 
 // Up create and start containers
-func (wrapper *PluginWrapper) Deploy(ctx context.Context, workingDir, host, projectName string, filePaths []string, envFilePath string, forceRereate bool) error {
-	output, err := wrapper.command(newUpCommand(filePaths, forceRereate), workingDir, host, projectName, envFilePath)
+func (wrapper *PluginWrapper) Deploy(ctx context.Context, workingDir, host, projectName string, filePaths []string, envFilePath string, forceRecreate bool) error {
+	output, err := wrapper.command(newUpCommand(filePaths, forceRecreate), workingDir, host, projectName, envFilePath)
 	if len(output) != 0 {
 		if err != nil {
 			return err
 		}
 
-		log.Printf("[INFO] [compose,internal,composeplugin] [message: Stack deployment successful]")
-		log.Printf("[DEBUG] [compose,internal,composeplugin] [output: %s]", output)
+		log.Printf("[INFO] [docker compose] [message: Stack deployment successful]")
+		log.Printf("[DEBUG] [docker compose] [output: %s]", output)
 	}
 
 	return err
@@ -84,8 +54,8 @@ func (wrapper *PluginWrapper) Remove(ctx context.Context, workingDir, host, proj
 			return err
 		}
 
-		log.Printf("[INFO] [compose,internal,composeplugin] [message: Stack removal successful]")
-		log.Printf("[DEBUG] [compose,internal,composeplugin] [output: %s]", output)
+		log.Printf("[INFO] [docker compose] [message: Stack removal successful]")
+		log.Printf("[DEBUG] [docker compose] [output: %s]", output)
 	}
 
 	return err
@@ -99,16 +69,16 @@ func (wrapper *PluginWrapper) Pull(ctx context.Context, workingDir, host, projec
 			return err
 		}
 
-		log.Printf("[INFO] [compose,internal,composeplugin] [message: Stack pull successful]")
-		log.Printf("[DEBUG] [compose,internal,composeplugin] [output: %s]", output)
+		log.Printf("[INFO] [docker compose] [message: Stack pull successful]")
+		log.Printf("[DEBUG] [docker compose] [output: %s]", output)
 	}
 
 	return err
 }
 
 // Command exectue a docker-compose commanåd
-func (wrapper *PluginWrapper) command(command composeCommand, workingDir, url, projectName, envFilePath string) ([]byte, error) {
-	program := utils.ProgramPath(wrapper.binaryPath, "docker")
+func (wrapper *PluginWrapper) command(command composeCommand, workingDir, host, projectName, envFilePath string) ([]byte, error) {
+	program := utils.ProgramPath(wrapper.binaryPath, "docker-compose")
 
 	if projectName != "" {
 		command.WithProjectName(projectName)
@@ -116,6 +86,10 @@ func (wrapper *PluginWrapper) command(command composeCommand, workingDir, url, p
 
 	if envFilePath != "" {
 		command.WithEnvFilePath(envFilePath)
+	}
+
+	if host != "" {
+		command.WithHost(host)
 	}
 
 	var stderr bytes.Buffer
@@ -126,11 +100,6 @@ func (wrapper *PluginWrapper) command(command composeCommand, workingDir, url, p
 		args = append(args, "--config", wrapper.configPath)
 	}
 
-	if url != "" {
-		args = append(args, "-H", url)
-	}
-
-	args = append(args, "compose")
 	args = append(args, command.ToArgs()...)
 
 	cmd := exec.Command(program, args...)
@@ -191,8 +160,8 @@ func (command *composeCommand) WithEnvFilePath(envFilePath string) {
 	command.args = append(command.args, "--env-file", envFilePath)
 }
 
-func (command *composeCommand) WithURL(url string) {
-	command.args = append(command.args, "-H", url)
+func (command *composeCommand) WithHost(host string) {
+	command.args = append(command.args, "-H", host)
 }
 
 func (command *composeCommand) ToArgs() []string {

--- a/compose/internal/composeplugin/composeplugin.go
+++ b/compose/internal/composeplugin/composeplugin.go
@@ -77,7 +77,7 @@ func (wrapper *PluginWrapper) Pull(ctx context.Context, workingDir, host, projec
 	return err
 }
 
-// Command exectue a docker-compose command
+// Command execute a docker-compose command
 func (wrapper *PluginWrapper) command(command composeCommand, workingDir, host, projectName, envFilePath string) ([]byte, error) {
 	program := utils.ProgramPath(wrapper.binaryPath, "docker-compose")
 

--- a/compose/internal/composeplugin/composeplugin.go
+++ b/compose/internal/composeplugin/composeplugin.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"log"
+	"os"
 	"os/exec"
 	"strings"
 
@@ -95,15 +96,17 @@ func (wrapper *PluginWrapper) command(command composeCommand, workingDir, host, 
 	var stderr bytes.Buffer
 
 	args := []string{}
-
-	if wrapper.configPath != "" {
-		args = append(args, "--config", wrapper.configPath)
-	}
-
 	args = append(args, command.ToArgs()...)
 
 	cmd := exec.Command(program, args...)
 	cmd.Dir = workingDir
+
+	if wrapper.configPath != "" {
+		if wrapper.configPath != "" {
+			cmd.Env = os.Environ()
+			cmd.Env = append(cmd.Env, "DOCKER_CONFIG="+wrapper.configPath)
+		}
+	}
 
 	cmd.Stderr = &stderr
 
@@ -146,10 +149,6 @@ func newDownCommand(filePaths []string) composeCommand {
 
 func newPullCommand(filePaths []string) composeCommand {
 	return newCommand([]string{"pull"}, filePaths)
-}
-
-func (command *composeCommand) WithConfigPath(configPath string) {
-	command.args = append(command.args, "--config", configPath)
 }
 
 func (command *composeCommand) WithProjectName(projectName string) {

--- a/compose/internal/composeplugin/composeplugin.go
+++ b/compose/internal/composeplugin/composeplugin.go
@@ -77,7 +77,7 @@ func (wrapper *PluginWrapper) Pull(ctx context.Context, workingDir, host, projec
 	return err
 }
 
-// Command exectue a docker-compose commanåd
+// Command exectue a docker-compose command
 func (wrapper *PluginWrapper) command(command composeCommand, workingDir, host, projectName, envFilePath string) ([]byte, error) {
 	program := utils.ProgramPath(wrapper.binaryPath, "docker-compose")
 

--- a/compose/internal/composeplugin/composeplugin_test.go
+++ b/compose/internal/composeplugin/composeplugin_test.go
@@ -17,7 +17,7 @@ import (
 
 func checkPrerequisites(t *testing.T) {
 	if _, err := os.Stat("docker-compose"); errors.Is(err, os.ErrNotExist) {
-		t.Fatal("docker-compose binary not found, please run download.sh and re-run this suite")
+		t.Fatal("docker-compose binary not found, please run download.sh and re-run this test suite")
 	}
 }
 

--- a/libstack.go
+++ b/libstack.go
@@ -5,7 +5,7 @@ import (
 )
 
 type Deployer interface {
-	Deploy(ctx context.Context, workingDir, host, projectName string, filePaths []string, envFilePath string, forceRereate bool) error
+	Deploy(ctx context.Context, workingDir, host, projectName string, filePaths []string, envFilePath string, forceRecreate bool) error
 	Remove(ctx context.Context, workingDir, host, projectName string, filePaths []string, envFilePath string) error
 	Pull(ctx context.Context, workingDir, host, projectName string, filePaths []string, envFilePath string) error
 }


### PR DESCRIPTION
The standard install of the docker-compose binary would call docker compose via the docker binary i.e. `docker compose ...`
However, we can actually call it directly and this is mentioned in the documentation.  

Therefore I've switched it back to the old method but with the new v2 binary.  This simplifies a lot of code and Dockerfile setup.

There is a tech debt ticket to remove this library completely.  As it's now doing very little

See: [EE-3631](https://portainer.atlassian.net/browse/EE-3631)